### PR TITLE
update docker command to include ulimit stack size argument

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -520,7 +520,7 @@
                 var indent = "    ";
                 var cmd = this.highlightCmd("docker") + " pull " + fullImg + "\n" +
                     this.highlightCmd("docker") + " run --" + this.highlightFlag("gpus") + " all --" + this.highlightFlag("rm") + " -" + this.highlightFlag("it") + " \\\n" +
-                    indent + "--" + this.highlightFlag("shm-size") + "=1g --" + this.highlightFlag("ulimit") + " memlock=-1" + " \\\n" +
+                    indent + "--" + this.highlightFlag("shm-size") + "=1g --" + this.highlightFlag("ulimit") + " memlock=-1 --" + this.highlightFlag("ulimit") + " stack=67108864" + " \\\n" +
                     (portOptions ? indent + portOptions + "\\\n" : "") +
                     indent + fullImg;
                 return cmd;


### PR DESCRIPTION
found while checking out some issues, should prevent additional multiGPU challenges, and brings us into further alignment with DLFW's examples https://docs.nvidia.com/deeplearning/frameworks/user-guide/index.html#digits_running